### PR TITLE
When event completed when assigned, remove relevant keys from firebase

### DIFF
--- a/app/src/actions/dataSourceActions.js
+++ b/app/src/actions/dataSourceActions.js
@@ -178,17 +178,17 @@ export function takeEvent(event) {
 export function updateEventStatus(event, status) {
   return ((dispatch, getState) => {
     const dispatcher = getState().dataSource.user.id;
-    const updatedEvent = Object.assign({}, event, {status, dispatcher})
+    const updatedEvent = Object.assign({}, event, {status, dispatcher});
     
-    const updates = {}
+    const updates = {};
     
     if(status === EventStatus.Completed) {
       // If status is completed, we need to remove assignment from user
-      updatedEvent.assignedTo = null
-      updates[`volunteer/${event.assignedTo}/EventKey`] = null
+      updatedEvent.assignedTo = null;
+      updates[`volunteer/${event.assignedTo}/EventKey`] = null;
     }
     
-    updates[`events/${event.key}`] = updatedEvent
+    updates[`events/${event.key}`] = updatedEvent;
     
     firebase.database().ref().update(updates, (err) => {
       if (err) {

--- a/app/src/actions/dataSourceActions.js
+++ b/app/src/actions/dataSourceActions.js
@@ -178,8 +178,19 @@ export function takeEvent(event) {
 export function updateEventStatus(event, status) {
   return ((dispatch, getState) => {
     const dispatcher = getState().dataSource.user.id;
-    const updatedEvent = Object.assign({}, event, {status, dispatcher});
-    firebase.database().ref('events/' + event.key).set(updatedEvent, (err) => {
+    const updatedEvent = Object.assign({}, event, {status, dispatcher})
+    
+    const updates = {}
+    
+    if(status === EventStatus.Completed) {
+      // If status is completed, we need to remove assignment from user
+      updatedEvent.assignedTo = null
+      updates[`volunteer/${event.assignedTo}/EventKey`] = null
+    }
+    
+    updates[`events/${event.key}`] = updatedEvent
+    
+    firebase.database().ref().update(updates, (err) => {
       if (err) {
         dispatch(setError('Failed to update!', err));
       } else {


### PR DESCRIPTION
This relates to https://github.com/startach/yedidim-native/pull/23 - when an event is completed from the dispatcher app, it doesn't remove relevant assignment properties of the event and user. That causes the user to be locked to the event. This PR fixes that.